### PR TITLE
Fix for 'files.format' on Windows

### DIFF
--- a/lib/ru/file.rb
+++ b/lib/ru/file.rb
@@ -38,7 +38,12 @@ module Ru
     end
 
     def group
-      Etc.getgrgid(gid).name
+      grgid = Etc.getgrgid(gid)
+      if grgid.nil?       # running on Windows
+        ''
+      else
+        grgid.name
+      end
     end
 
     def mode
@@ -54,7 +59,12 @@ module Ru
     end
 
     def owner
-      Etc.getpwuid(uid).name
+      pwuid = Etc.getpwuid(uid)
+      if pwuid.nil?       # running on Windows
+        ''
+      else
+        pwuid.name
+      end
     end
 
     def size


### PR DESCRIPTION
Thanks for ru2! I'm really enjoying using it!

It works fine on Ubuntu, but 'files.format' wasn't working on Windows with Git Bash:

	$ printf 'test' | ru 'files.format'
	undefined method `name' for nil:NilClass
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/process.rb:45:in `instance_eval'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/file.rb:26:in `format'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/array.rb:20:in `block in format'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/array.rb:19:in `map!'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/array.rb:19:in `format'
	(eval):1:in `run'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/process.rb:45:in `instance_eval'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/lib/ru/process.rb:45:in `run'
	C:/Ruby231p112/lib/ruby/gems/2.3.0/gems/ru2-2.1.4/bin/ru:7:in `<top (required)>'
	C:/Ruby231p112/bin/ru:22:in `load'
	C:/Ruby231p112/bin/ru:22:in `<main>'

This is a simple fix.  Afterwards:

	$ printf 'test' | ru 'files.format'
	644                     0       2017-01-25      11:32   test
