### PR TITLE
Support no space after !, as in ru '!2+2'

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ $ ru 'map(:to_i).sum' myfile myfile
 10
 ```
 
-You can also run Ruby code without any input by prepending a `! `:
+You can also run Ruby code without any input by prepending a `=`:
 
 ```bash
-$ ru '! 2 + 3'
+$ ru '=2 + 3'
 5
 ```
 

--- a/lib/ru/process.rb
+++ b/lib/ru/process.rb
@@ -19,7 +19,7 @@ module Ru
         return
       end
 
-      @stdin = get_stdin(args, @options[:stream]) unless @code.start_with?('! ')
+      @stdin = get_stdin(args, @options[:stream]) unless @code.start_with?('!')
       @code  = prepare_code(@code)
 
       context =
@@ -53,8 +53,8 @@ module Ru
       if code.kind_of?(String)
         if code.start_with?('[')
           code = 'to_self' + code
-        elsif code.start_with?('! ')
-          code = code[2..-1]
+        elsif code.start_with?('!')
+          code = code[1..-1]
         end
       end
       code

--- a/lib/ru/process.rb
+++ b/lib/ru/process.rb
@@ -19,7 +19,7 @@ module Ru
         return
       end
 
-      @stdin = get_stdin(args, @options[:stream]) unless @code.start_with?('!')
+      @stdin = get_stdin(args, @options[:stream]) unless @code.start_with?('=')
       @code  = prepare_code(@code)
 
       context =
@@ -53,7 +53,7 @@ module Ru
       if code.kind_of?(String)
         if code.start_with?('[')
           code = 'to_self' + code
-        elsif code.start_with?('!')
+        elsif code.start_with?('=')
           code = code[1..-1]
         end
       end

--- a/spec/lib/process_spec.rb
+++ b/spec/lib/process_spec.rb
@@ -57,8 +57,8 @@ describe Ru::Process do
       expect(out).to eq("foo\nfoo\nfoo")
     end
 
-    it "runs code prepended by '! '" do
-      out = run('! 2 + 3')
+    it "runs code prepended by '='" do
+      out = run('=2 + 3')
       expect(out).to eq('5')
     end
 


### PR DESCRIPTION
ru '! 2+2' works as expected:

	~/temp/ru_test$ru '! 2+2'
	4

But if we accidentally leave out the space, ru seems to hang:

	~/temp/ru_test$ru '!2+2'
	[[no output, program seems to be hung]]

If we type ^C, we see the program was reading from stdin:

	^C/var/lib/gems/2.3.0/gems/ru2-2.1.4/lib/ru/process.rb:116:in `read': Interrupt
		from /var/lib/gems/2.3.0/gems/ru2-2.1.4/lib/ru/process.rb:116:in `get_stdin'
		from /var/lib/gems/2.3.0/gems/ru2-2.1.4/lib/ru/process.rb:22:in `run'
		from /var/lib/gems/2.3.0/gems/ru2-2.1.4/bin/ru:7:in `<top (required)>'
		from /usr/local/bin/ru:23:in `load'
		from /usr/local/bin/ru:23:in `<main>'

This fix gives the expected result, even without the space:

	~/temp/ru_test$ru '!2+2'
	4

