### PR TITLE
Fix 5 pathname failures when running specs

### DIFF
--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module FixturesHelper
   def fixture_path(*args)
     directory = Pathname.new(File.dirname(File.absolute_path(__FILE__)))


### PR DESCRIPTION
Running rake results in 5 failures related to Pathname:

	$rake
	/usr/bin/ruby2.3 -I/var/lib/gems/2.3.0/gems/rspec-support-3.5.0/lib:/var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*/\*_spec.rb

	Randomized with seed 49305
	.............F.......F...F.F.........F...........................

	Failures:

	  1) stream examples misc stream examples sorting an Apache access log by response time sorts
		 Failure/Error: directory = Pathname.new(File.dirname(File.absolute_path(__FILE__)))

		 NameError:
		   uninitialized constant FixturesHelper::Pathname
		 # ./spec/support/fixtures_helper.rb:3:in `fixture_path'
		 # ./spec/examples/stream_examples_spec.rb:29:in `block (4 levels) in <top (required)>'

	[4 similar failures omitted]

	Finished in 0.06409 seconds (files took 0.31775 seconds to load)
	65 examples, 5 failures

After this fix:

	$rake
	/usr/bin/ruby2.3 -I/var/lib/gems/2.3.0/gems/rspec-support-3.5.0/lib:/var/lib/gems/2.3.0/gems/rspec-core-3.5.4/lib /var/lib/gems/2.3.0/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*/\*_spec.rb

	Randomized with seed 53208
	.................................................................

	Finished in 0.07444 seconds (files took 0.31773 seconds to load)
	65 examples, 0 failures

	Randomized with seed 53208

