### PR TITLE
Only require ActiveSupport if it is actually used

### DIFF
--- a/lib/ru.rb
+++ b/lib/ru.rb
@@ -1,5 +1,3 @@
-require 'active_support/all'
-
 directory = File.dirname(File.absolute_path(__FILE__))
 Dir.glob("#{directory}/ru/*.rb") { |file| require file }
 

--- a/lib/ru/option_printer.rb
+++ b/lib/ru/option_printer.rb
@@ -1,9 +1,10 @@
 require 'erb'
+require 'ostruct'
 
 module Ru
   class OptionPrinter
     def exists?(option_key)
-      options[option_key].present?
+      ! (options[option_key].nil? || options[option_key].empty?)
     end
 
     def run(option_key, option_value=nil)

--- a/lib/ru/process.rb
+++ b/lib/ru/process.rb
@@ -14,7 +14,7 @@ module Ru
       args  = ARGV.dup
       @code = args.shift
 
-      if @code.blank?
+      if @code.empty?
         $stderr.puts @option_printer.run(:help)
         return
       end
@@ -43,7 +43,13 @@ module Ru
           end
         end
 
-      output = context.instance_eval(@parsed[:code])
+      begin
+        output = context.instance_eval(@parsed[:code])
+      rescue NoMethodError
+        require 'active_support/all'
+
+        output = context.instance_eval(@parsed[:code])
+      end
       output = @stdin if output == nil
 
       prepare_output(output)
@@ -108,7 +114,7 @@ module Ru
     end
 
     def get_stdin(paths, stream)
-      if paths.present?
+      if ! paths.empty?
         if stream
           ::File.open(paths[0])
         else

--- a/lib/ru/process.rb
+++ b/lib/ru/process.rb
@@ -14,7 +14,7 @@ module Ru
       args  = ARGV.dup
       @code = args.shift
 
-      if @code.blank?
+      if @code.empty?
         $stderr.puts @option_printer.run(:help)
         return
       end
@@ -43,7 +43,13 @@ module Ru
           end
         end
 
-      output = context.instance_eval(@parsed[:code])
+      begin
+        output = context.instance_eval(@parsed[:code])
+      rescue NoMethodError
+        require 'active_support/all'
+
+        output = context.instance_eval(@parsed[:code])
+      end
       output = @stdin if output == nil
 
       prepare_output(output)
@@ -58,6 +64,7 @@ module Ru
       elsif code.start_with?('=')
         { code: code[1..-1], get_stdin: false }
       elsif code.start_with?('!')
+        require 'active_support/deprecation'
         ActiveSupport::Deprecation.warn %('!1+2' syntax is going to be replaced with '=1+2')
         { code: code[1..-1], get_stdin: false }
       else
@@ -108,7 +115,7 @@ module Ru
     end
 
     def get_stdin(paths, stream)
-      if paths.present?
+      if ! paths.empty?
         if stream
           ::File.open(paths[0])
         else


### PR DESCRIPTION
This pull request is about speeding up ru.  See https://github.com/tombenner/ru/issues/4

As a baseline, I ran this command

    time ru '=2+2'
10 times on ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu], Ubuntu 16.10 as a VirtualBox VM on Windows 10 on a Thinkpad T530 laptop, Core i5-3320M at 2.6GHz, on an SSD.

The average of the user + sys values was .4136 seconds.

I then made a change to only execute the ```require 'active_support/all'``` if ActiveSupport is actually needed, which it isn't in the above case.

Re-running the command 10 times after this change gives an average user + sys value of .0944 seconds, which is 22.82% of the previous times, a speedup of a little more than a factor of 4.

To time the case where ActiveSupport is used, I ran this command

    time ru '=[1,2,3].sum'
	
Before the change the average of the user + sys values was .4048 seconds.
	
After the change the average of the user + sys values was .4232 seconds.

This is a ratio of 1.044, or an apparent slowdown of 4.4%.  However, this benchmarking is very simplistic, so this value is certainly not exact.  We expected the ActiveSupport case to be a little slower, but this shows that the slowdown is not substantial.

In actual use, the speedup in the non-ActiveSupport case is quite noticable, but the ActiveSupport case seems the same.

I suspect that most uses of ru do not require ActiveSupport.  For example, running

    rake
reports "65 examples", all of which pass.  If we temporarily modify the code to never require ActiveSupport, only 3 of those examples become failures.

Details of the change:

In 3 places, the code called blank? or present?, both of which are defined in ActiveSupport.  These were rewritten to use empty? and nil?

option_printer.rb uses OpenStruct, which is required by 'active_support/all'.  An explicit require 'ostruct' was added.