### PR TITLE
Prevent the specs from failing for seed 26462

### DIFF
--- a/lib/ru/stream.rb
+++ b/lib/ru/stream.rb
@@ -1,3 +1,5 @@
+# The following require is necessary otherwise specs will occasionally fail,
+# depending on the order in which they run.  seed 26462 will cause a failure.
 require 'set'
 
 class Enumerator::Lazy

--- a/lib/ru/stream.rb
+++ b/lib/ru/stream.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 class Enumerator::Lazy
   def [](number_or_range, length=1)
     if number_or_range.kind_of? Range


### PR DESCRIPTION
The specs fail for seed 26462:

	$ rspec --order rand:26462

	Randomized with seed 26462
	..F..............................................................

	Failures:

	  1) stream examples sed stream examples make duplicate lines unique dedupes
		 Failure/Error: output = context.instance_eval(@parsed[:code])

		 NameError:
		   uninitialized constant Set
		   Did you mean?  Set
		 # ./lib/ru/process.rb:47:in `instance_eval'
		 # ./lib/ru/stream.rb:116:in `method_missing'
		 # (eval):1:in `run'
		 # ./lib/ru/process.rb:47:in `instance_eval'
		 # ./lib/ru/process.rb:47:in `run'
		 # ./spec/support/process_helper.rb:20:in `run'
		 # ./spec/support/process_helper.rb:28:in `run_stream'
		 # ./spec/examples/stream_examples_spec.rb:107:in `block (4 levels) in <top (required)>'

	Finished in 0.796 seconds (files took 0.2135 seconds to load)
	65 examples, 1 failure

	Failed examples:

	rspec ./spec/examples/stream_examples_spec.rb:105 # stream examples sed stream examples make duplicate lines unique dedupes

	Randomized with seed 26462
	
This happens because usually 'set' is required by another spec before stream.rb.  But occasionally, depending on the seed, stream.rb is executed before 'set' is required.  This fix explicitly requires 'set' in stream.rb.  After this fix:

	$ rspec --order rand:26462

	Randomized with seed 26462
	.................................................................

	Finished in 0.8045 seconds (files took 0.224 seconds to load)
	65 examples, 0 failures

	Randomized with seed 26462

We ran this simple code to test with all seeds between 0 and 65535.  They all pass.

	0.upto(65535) do |i|
	  unless system "rspec --seed #{i}"
	    break
	  end
	end


	$ ruby run_specs.rb

	Randomized with seed 0
	.................................................................

	Finished in 1.09 seconds (files took 0.2325 seconds to load)
	65 examples, 0 failures

	Randomized with seed 0

	Randomized with seed 1
	.................................................................

	Finished in 0.874 seconds (files took 0.2515 seconds to load)
	65 examples, 0 failures

	Randomized with seed 1

			...snip...

	Randomized with seed 65534
	.................................................................

	Finished in 0.839 seconds (files took 0.2225 seconds to load)
	65 examples, 0 failures

	Randomized with seed 65534

	Randomized with seed 65535
	.................................................................

	Finished in 0.8005 seconds (files took 0.215 seconds to load)
	65 examples, 0 failures

	Randomized with seed 65535

